### PR TITLE
リネーム時は base のグラフのリネーム対象ファイルの周辺ノードを表示する

### DIFF
--- a/src/getFullGraph.ts
+++ b/src/getFullGraph.ts
@@ -17,8 +17,8 @@ declare let danger: DangerDSLType;
  */
 export default function getFullGraph() {
   return new Promise<{
-    headGraph: Graph;
-    baseGraph: Graph;
+    fullHeadGraph: Graph;
+    fullBaseGraph: Graph;
     meta: Meta;
   }>(resolve => {
     // head の Graph を生成
@@ -27,13 +27,6 @@ export default function getFullGraph() {
     );
     log('fullHeadGraph.nodes.length:', fullHeadGraph.nodes.length);
     log('fullHeadGraph.relations.length:', fullHeadGraph.relations.length);
-    // head には deleted 対象はない
-    const headGraph = filterGraph(
-      [danger.git.modified_files, danger.git.created_files].flat(),
-      ['node_modules'],
-      fullHeadGraph,
-    );
-    log('headGraph:', headGraph);
 
     // base の Graph を生成するために base に checkout する
     execSync(`git fetch origin ${danger.github.pr.base.ref}`);
@@ -44,19 +37,9 @@ export default function getFullGraph() {
     );
     log('fullBaseGraph.nodes.length:', fullBaseGraph.nodes.length);
     log('fullBaseGraph.relations.length:', fullBaseGraph.relations.length);
-    const baseGraph = filterGraph(
-      [
-        danger.git.modified_files,
-        danger.git.created_files,
-        danger.git.deleted_files,
-      ].flat(),
-      ['node_modules'],
-      fullBaseGraph,
-    );
-    log('baseGraph:', baseGraph);
     // head に戻す
     execSync(`git fetch origin ${danger.github.pr.head.ref}`);
     execSync(`git checkout ${danger.github.pr.head.ref}`);
-    resolve({ headGraph, baseGraph, meta });
+    resolve({ fullHeadGraph, fullBaseGraph, meta });
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,26 +37,26 @@ async function makeGraph() {
     return;
   }
 
-  const [renamed, { headGraph, baseGraph, meta }] = await Promise.all([
+  const [renamed, { fullHeadGraph, fullBaseGraph, meta }] = await Promise.all([
     getRenameFiles(),
     getFullGraph(),
   ]);
   log('renamed.length:', renamed?.length);
-  log('headGraph.nodes.length:', headGraph.nodes.length);
-  log('baseGraph.nodes.length:', baseGraph.nodes.length);
+  log('fullHeadGraph.nodes.length:', fullHeadGraph.nodes.length);
+  log('fullBaseGraph.nodes.length:', fullBaseGraph.nodes.length);
   log('meta:', meta);
 
   // head のグラフが空の場合は何もしない
-  if (headGraph.nodes.length === 0) return;
+  if (fullHeadGraph.nodes.length === 0) return;
 
-  const hasRenamed = headGraph.nodes.some(headNode =>
+  const hasRenamed = fullHeadGraph.nodes.some(headNode =>
     renamed?.map(({ filename }) => filename).includes(headNode.path),
   );
 
   if (deleted.length !== 0 || hasRenamed) {
     // ファイルの削除またはリネームがある場合は Graph を2つ表示する
-    await output2Graphs(baseGraph, headGraph, meta, renamed);
+    await output2Graphs(fullBaseGraph, fullHeadGraph, meta, renamed);
   } else {
-    await outputGraph(baseGraph, headGraph, meta, renamed);
+    await outputGraph(fullBaseGraph, fullHeadGraph, meta, renamed);
   }
 }


### PR DESCRIPTION
以下の issue を解決。
https://github.com/ysk8hori/danger-plugin-typescript-graph/issues/47

もともと、 getFullGraph の中で git における modified, created, deleted の情報をもとに filterGraph 関数で表示対象とするノードを絞り込んでいた。その際、 rename の情報は rename 後のファイル名が modified に含まれるのみであったため、base グラフ内のリネーム前のファイルが include されていなかった。

本PRによって、 filterGraph に rename の情報を加味した include 情報を渡すようになり、この問題が解消された。