### PR TITLE
Fix: 出力可能なグラフがない場合は何も出力しない

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "commit": "git-cz",
     "commitmsg": "validate-commit-msg",
     "build": "tsc",
+    "type-check": "tsc --noEmit",
     "test": "jest",
     "predocs": "rm -rf docs/",
     "docs": "esdoc -c .esdoc.json",

--- a/src/outputGraph/outputGraph.test.ts
+++ b/src/outputGraph/outputGraph.test.ts
@@ -1,0 +1,30 @@
+import { outputGraph } from './outputGraph';
+
+beforeEach(() => {
+  global.markdown = jest.fn();
+});
+
+afterEach(() => {
+  global.markdown = undefined;
+});
+
+test('出力可能なグラフがない場合は何も出力しない', () => {
+  const graph = {
+    nodes: [],
+    relations: [],
+  };
+  const meta = {
+    rootDir: '',
+  };
+  const renamed = undefined;
+  global.danger = {
+    github: { pr: { title: 'My Test Title' } },
+    git: {
+      modified_files: [],
+      created_files: [],
+      deleted_files: [],
+    },
+  };
+  outputGraph(graph, graph, meta, renamed);
+  expect(global.markdown).not.toHaveBeenCalled();
+});

--- a/src/outputGraph/outputGraph.ts
+++ b/src/outputGraph/outputGraph.ts
@@ -32,8 +32,13 @@ export function outputGraph(
     renamed,
   );
 
-  // グラフが大きすぎる場合は表示しない
+  if (graph.nodes.length === 0) {
+    // グラフが空の場合は表示しない
+    return;
+  }
+
   if (graph.nodes.length > getMaxSize()) {
+    // グラフが大きすぎる場合は表示しない
     markdown(`
 ## TypeScript Graph - Diff
 
@@ -95,6 +100,11 @@ export async function output2Graphs(
     fullBaseGraph,
     fullHeadGraph,
   );
+
+  if (baseGraph.nodes.length === 0 && headGraph.nodes.length === 0) {
+    // base と head のグラフが空の場合は表示しない
+    return;
+  }
 
   // base または head のグラフが大きすぎる場合は表示しない
   if (


### PR DESCRIPTION
「出力可能なグラフがない場合は何も出力しない」仕様であったが、空のグラフを出力してしまっていたので修正する。