### PR TITLE
変更対象のファイルが同階層の index.ts などから参照されている場合その index.ts への依存ファイルも表示可能とする

### DIFF
--- a/.danger-tsgrc.json
+++ b/.danger-tsgrc.json
@@ -1,5 +1,6 @@
 {
   "maxSize": 100,
   "debug": true,
-  "exclude": ["node_modules", ".test.ts", ".spec.ts", ".d.ts", "/utils"]
+  "exclude": ["node_modules", ".test.ts", ".spec.ts", ".d.ts", "/utils"],
+  "includeIndexFileDependencies": true
 }

--- a/src/graph/applyMutualDifferences.ts
+++ b/src/graph/applyMutualDifferences.ts
@@ -9,6 +9,7 @@ import { filterGraph } from '@ysk8hori/typescript-graph/dist/src/graph/filterGra
 import { exclude } from '../utils/config';
 import { extractAbstractionTargetFromGraphs } from './extractAbstractionTargetFromGraphs';
 import { createTsgCommand } from './createTsgCommand';
+import { createIncludeList } from './createIncludeList';
 
 /**
  * ２つのグラフの差分を互いに反映する。
@@ -25,13 +26,13 @@ export default function applyMutualDifferences(
   fullBaseGraph: Graph,
   fullHeadGraph: Graph,
 ) {
-  const includes = [
-    ...created,
-    ...modified,
-    ...(renamed
-      ?.flatMap(diff => [diff.previous_filename, diff.filename])
-      .filter(Boolean) ?? []),
-  ];
+  const includes = createIncludeList({
+    created,
+    deleted,
+    modified,
+    renamed,
+    graphs: [fullBaseGraph, fullHeadGraph],
+  });
   log('includes:', includes);
 
   const abstractionTargetsForBase = pipe(

--- a/src/graph/createIncludeList.test.ts
+++ b/src/graph/createIncludeList.test.ts
@@ -1,0 +1,111 @@
+import { Node, Relation } from '@ysk8hori/typescript-graph/dist/src/models';
+import { createIncludeList } from './createIncludeList';
+
+let ENV_ORG: NodeJS.ProcessEnv;
+
+beforeAll(() => {
+  ENV_ORG = process.env;
+});
+
+afterEach(() => {
+  process.env = ENV_ORG;
+});
+
+test('新規作成、更新、削除、リネーム前後のファイルが include 対象となる', () => {
+  process.env.TSG_INCLUDE_INDEX_FILE_DEPENDENCIES = 'false';
+  expect(
+    createIncludeList({
+      created: ['created.ts'],
+      deleted: ['deleted.ts'],
+      modified: ['modified.ts'],
+      renamed: [{ previous_filename: 'before.ts', filename: 'after.ts' }],
+      graphs: [],
+    }),
+  ).toEqual([
+    'created.ts',
+    'deleted.ts',
+    'modified.ts',
+    'before.ts',
+    'after.ts',
+  ]);
+});
+
+test('TSG_INCLUDE_INDEX_FILE_DEPENDENCIES が false の場合は include 対象となるファイルを参照している index.ts を含めない', () => {
+  process.env.TSG_INCLUDE_INDEX_FILE_DEPENDENCIES = 'false';
+  expect(
+    createIncludeList({
+      created: [],
+      deleted: [],
+      modified: ['src/a.ts'],
+      renamed: [],
+      graphs: [
+        {
+          nodes: [
+            {
+              changeStatus: 'not_modified',
+              name: 'a.ts',
+              path: 'src/a.ts',
+            } satisfies Node,
+          ],
+          relations: [
+            {
+              from: {
+                changeStatus: 'not_modified',
+                name: 'index.ts',
+                path: 'src/index.ts',
+              } satisfies Node,
+              to: {
+                changeStatus: 'not_modified',
+                name: 'a.ts',
+                path: 'src/a.ts',
+              } satisfies Node,
+              changeStatus: 'not_modified',
+              fullText: '',
+              kind: 'depends_on',
+            } satisfies Relation,
+          ],
+        },
+      ],
+    }),
+  ).toEqual(['src/a.ts']);
+});
+
+test('TSG_INCLUDE_INDEX_FILE_DEPENDENCIES が false の場合は include 対象となるファイルを参照している index.ts を含める', () => {
+  process.env.TSG_INCLUDE_INDEX_FILE_DEPENDENCIES = 'true';
+  expect(
+    createIncludeList({
+      created: [],
+      deleted: [],
+      modified: ['src/a.ts'],
+      renamed: [],
+      graphs: [
+        {
+          nodes: [
+            {
+              changeStatus: 'not_modified',
+              name: 'a.ts',
+              path: 'src/a.ts',
+            } satisfies Node,
+          ],
+          relations: [
+            {
+              from: {
+                changeStatus: 'not_modified',
+                name: 'index.ts',
+                path: 'src/index.ts',
+              } satisfies Node,
+              to: {
+                changeStatus: 'not_modified',
+                name: 'a.ts',
+                path: 'src/a.ts',
+              } satisfies Node,
+              changeStatus: 'not_modified',
+              fullText: '',
+              kind: 'depends_on',
+            } satisfies Relation,
+          ],
+        },
+      ],
+    }),
+  ).toEqual(['src/a.ts', 'src/index.ts']);
+});

--- a/src/graph/createIncludeList.ts
+++ b/src/graph/createIncludeList.ts
@@ -1,0 +1,34 @@
+import { Graph } from '@ysk8hori/typescript-graph/dist/src/models';
+import { isIncludeIndexFileDependencies } from '../utils/config';
+import { extractIndexFileDependencies } from './extractIndexFileDependencies';
+
+export function createIncludeList({
+  created,
+  deleted,
+  modified,
+  renamed,
+  graphs,
+}: {
+  created: string[];
+  deleted: string[];
+  modified: string[];
+  renamed:
+    | { filename: string; previous_filename: string | undefined }[]
+    | undefined;
+  graphs: Graph[];
+}) {
+  const tmp = [
+    ...created,
+    ...deleted,
+    ...modified,
+    ...(renamed
+      ?.flatMap(diff => [diff.previous_filename, diff.filename])
+      .filter(Boolean) ?? []),
+  ];
+  return isIncludeIndexFileDependencies()
+    ? [
+        ...tmp,
+        ...extractIndexFileDependencies({ graphs, includeFilePaths: tmp }),
+      ]
+    : tmp;
+}

--- a/src/graph/extractIndexFileDependencies/extractIndexFileDependencies.test.ts
+++ b/src/graph/extractIndexFileDependencies/extractIndexFileDependencies.test.ts
@@ -1,0 +1,108 @@
+import { Node, Relation } from '@ysk8hori/typescript-graph/dist/src/models';
+import { extractIndexFileDependencies } from './extractIndexFileDependencies';
+
+test('すべて空配列でもエラーとならない', () => {
+  expect(
+    extractIndexFileDependencies({
+      includeFilePaths: [],
+      graph: { nodes: [], relations: [] },
+    }),
+  ).toEqual([]);
+});
+
+const main = {
+  changeStatus: 'not_modified',
+  name: 'main.ts',
+  path: 'src/main.ts',
+} satisfies Node;
+const indexA = {
+  changeStatus: 'not_modified',
+  name: 'index.ts',
+  path: 'src/a/index.ts',
+} satisfies Node;
+const a = {
+  changeStatus: 'not_modified',
+  name: 'a.ts',
+  path: 'src/a/a.ts',
+} satisfies Node;
+const a2 = {
+  changeStatus: 'not_modified',
+  name: 'a2.ts',
+  path: 'src/a/a2.ts',
+} satisfies Node;
+const indexB = {
+  changeStatus: 'not_modified',
+  name: 'index.ts',
+  path: 'src/b/index.ts',
+} satisfies Node;
+const b = {
+  changeStatus: 'not_modified',
+  name: 'b.ts',
+  path: 'src/b/b.ts',
+} satisfies Node;
+const nodes = [main, indexA, a, a2, indexB, b];
+
+function relation(from: Node, to: Node): Relation {
+  return {
+    from: from,
+    to: to,
+    changeStatus: 'not_modified',
+    fullText: '',
+    kind: 'depends_on',
+  };
+}
+
+test('index.ts から参照されるノードが includeFilePath に含まれる場合はその index.ts を返す（通常ケース）', () => {
+  expect(
+    extractIndexFileDependencies({
+      includeFilePaths: [a.path, a2.path, b.path],
+      graph: {
+        nodes,
+        relations: [
+          // 抽出対象となる relation
+          relation(indexA, a),
+          // 抽出対象となる relation
+          relation(indexA, a2),
+          // 抽出対象とならない relation
+          relation(main, b),
+        ],
+      },
+    }),
+  ).toEqual([indexA.path]);
+});
+
+test('includeFilePaths が空配列でもエラーにならない', () => {
+  expect(
+    extractIndexFileDependencies({
+      includeFilePaths: [],
+      graph: {
+        nodes,
+        relations: [relation(indexA, a), relation(main, b)],
+      },
+    }),
+  ).toEqual([]);
+});
+
+test('includeFilePaths に空文字が含まれていても全ての index.ts が抽出対象になったりはしない', () => {
+  expect(
+    extractIndexFileDependencies({
+      includeFilePaths: [''],
+      graph: {
+        nodes,
+        relations: [relation(indexA, a), relation(main, b)],
+      },
+    }),
+  ).toEqual([]);
+});
+
+test('graph が空っぽでもエラーにならない', () => {
+  expect(
+    extractIndexFileDependencies({
+      includeFilePaths: ['a.ts', 'b.ts'],
+      graph: {
+        nodes: [],
+        relations: [],
+      },
+    }),
+  ).toEqual([]);
+});

--- a/src/graph/extractIndexFileDependencies/extractIndexFileDependencies.test.ts
+++ b/src/graph/extractIndexFileDependencies/extractIndexFileDependencies.test.ts
@@ -5,7 +5,7 @@ test('すべて空配列でもエラーとならない', () => {
   expect(
     extractIndexFileDependencies({
       includeFilePaths: [],
-      graph: { nodes: [], relations: [] },
+      graphs: [{ nodes: [], relations: [] }],
     }),
   ).toEqual([]);
 });
@@ -56,17 +56,19 @@ test('index.ts から参照されるノードが includeFilePath に含まれる
   expect(
     extractIndexFileDependencies({
       includeFilePaths: [a.path, a2.path, b.path],
-      graph: {
-        nodes,
-        relations: [
-          // 抽出対象となる relation
-          relation(indexA, a),
-          // 抽出対象となる relation
-          relation(indexA, a2),
-          // 抽出対象とならない relation
-          relation(main, b),
-        ],
-      },
+      graphs: [
+        {
+          nodes,
+          relations: [
+            // 抽出対象となる relation
+            relation(indexA, a),
+            // 抽出対象となる relation
+            relation(indexA, a2),
+            // 抽出対象とならない relation
+            relation(main, b),
+          ],
+        },
+      ],
     }),
   ).toEqual([indexA.path]);
 });
@@ -75,10 +77,12 @@ test('includeFilePaths が空配列でもエラーにならない', () => {
   expect(
     extractIndexFileDependencies({
       includeFilePaths: [],
-      graph: {
-        nodes,
-        relations: [relation(indexA, a), relation(main, b)],
-      },
+      graphs: [
+        {
+          nodes,
+          relations: [relation(indexA, a), relation(main, b)],
+        },
+      ],
     }),
   ).toEqual([]);
 });
@@ -87,10 +91,12 @@ test('includeFilePaths に空文字が含まれていても全ての index.ts �
   expect(
     extractIndexFileDependencies({
       includeFilePaths: [''],
-      graph: {
-        nodes,
-        relations: [relation(indexA, a), relation(main, b)],
-      },
+      graphs: [
+        {
+          nodes,
+          relations: [relation(indexA, a), relation(main, b)],
+        },
+      ],
     }),
   ).toEqual([]);
 });
@@ -99,10 +105,12 @@ test('graph が空っぽでもエラーにならない', () => {
   expect(
     extractIndexFileDependencies({
       includeFilePaths: ['a.ts', 'b.ts'],
-      graph: {
-        nodes: [],
-        relations: [],
-      },
+      graphs: [
+        {
+          nodes: [],
+          relations: [],
+        },
+      ],
     }),
   ).toEqual([]);
 });

--- a/src/graph/extractIndexFileDependencies/extractIndexFileDependencies.ts
+++ b/src/graph/extractIndexFileDependencies/extractIndexFileDependencies.ts
@@ -5,10 +5,10 @@ import { uniqueString } from '../../utils/reducer';
  * includes 対象のファイルが同階層の index.ts または index.tsx から参照されている場合、その index.ts のパスのリストを返却する。
  */
 export function extractIndexFileDependencies({
-  graph,
+  graphs,
   includeFilePaths,
 }: {
-  graph: Graph;
+  graphs: Graph[];
   includeFilePaths: string[];
 }): string[] {
   return includeFilePaths
@@ -16,13 +16,18 @@ export function extractIndexFileDependencies({
       from: path.split('/').slice(0, -1).join('/').concat('/index.'),
       to: path,
     }))
-    .map(hoge => (console.log(hoge), hoge))
     .map(
       ({ from, to }) =>
-        graph.relations.find(
-          relation =>
-            relation.from.path.startsWith(from) && relation.to.path === to,
-        )?.from.path,
+        graphs
+          .map(
+            graph =>
+              graph.relations.find(
+                relation =>
+                  relation.from.path.startsWith(from) &&
+                  relation.to.path === to,
+              )?.from.path,
+          )
+          .filter(Boolean)[0],
     )
     .reduce(uniqueString, [])
     .filter(Boolean);

--- a/src/graph/extractIndexFileDependencies/extractIndexFileDependencies.ts
+++ b/src/graph/extractIndexFileDependencies/extractIndexFileDependencies.ts
@@ -1,0 +1,29 @@
+import { Graph } from '@ysk8hori/typescript-graph/dist/src/models';
+import { uniqueString } from '../../utils/reducer';
+
+/**
+ * includes 対象のファイルが同階層の index.ts または index.tsx から参照されている場合、その index.ts のパスのリストを返却する。
+ */
+export function extractIndexFileDependencies({
+  graph,
+  includeFilePaths,
+}: {
+  graph: Graph;
+  includeFilePaths: string[];
+}): string[] {
+  return includeFilePaths
+    .map(path => ({
+      from: path.split('/').slice(0, -1).join('/').concat('/index.'),
+      to: path,
+    }))
+    .map(hoge => (console.log(hoge), hoge))
+    .map(
+      ({ from, to }) =>
+        graph.relations.find(
+          relation =>
+            relation.from.path.startsWith(from) && relation.to.path === to,
+        )?.from.path,
+    )
+    .reduce(uniqueString, [])
+    .filter(Boolean);
+}

--- a/src/graph/extractIndexFileDependencies/index.ts
+++ b/src/graph/extractIndexFileDependencies/index.ts
@@ -1,0 +1,1 @@
+export * from './extractIndexFileDependencies';

--- a/src/graph/mergeGraphsWithDifferences.ts
+++ b/src/graph/mergeGraphsWithDifferences.ts
@@ -11,6 +11,7 @@ import { filterGraph } from '@ysk8hori/typescript-graph/dist/src/graph/filterGra
 import { exclude } from '../utils/config';
 import { extractAbstractionTargetFromGraphs } from './extractAbstractionTargetFromGraphs';
 import { createTsgCommand } from './createTsgCommand';
+import { createIncludeList } from './createIncludeList';
 
 /** ２つのグラフからその差分を反映した１つのグラフを生成する */
 export default function mergeGraphsWithDifferences(
@@ -35,13 +36,13 @@ export default function mergeGraphsWithDifferences(
   log('mergedGraph.nodes.length:', mergedGraph.nodes.length);
   log('mergedGraph.relations.length:', mergedGraph.relations.length);
 
-  const includes = [
-    ...created,
-    ...modified,
-    ...(renamed
-      ?.flatMap(diff => [diff.previous_filename, diff.filename])
-      .filter(Boolean) ?? []),
-  ];
+  const includes = createIncludeList({
+    created,
+    deleted,
+    modified,
+    renamed,
+    graphs: [mergedGraph],
+  });
   log('includes:', includes);
 
   const abstractionTarget = pipe(includes, extractNoAbstractionDirs, dirs =>

--- a/src/graph/output2Graphs.test.ts
+++ b/src/graph/output2Graphs.test.ts
@@ -118,7 +118,7 @@ test('削除がある場合', async () => {
 
 
     \`\`\`bash
-    tsg  --include src/A.tsx --highlight src/A.tsx --exclude node_modules --abstraction src/1
+    tsg  --include src/B.tsx src/A.tsx --highlight src/B.tsx src/A.tsx --exclude node_modules --abstraction src/1
     \`\`\`
 
     ### Base Branch

--- a/src/utils/.test-danger-tsgrc.json
+++ b/src/utils/.test-danger-tsgrc.json
@@ -4,5 +4,6 @@
   "orientation": "LR",
   "debug": true,
   "inDetails": true,
-  "exclude": ["node_modules", ".test.ts", ".spec.ts", ".d.ts"]
+  "exclude": ["node_modules", ".test.ts", ".spec.ts", ".d.ts"],
+  "includeIndexFileDependencies": true
 }

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -3,6 +3,7 @@ import {
   getMaxSize,
   getOrientation,
   getTsconfigRoot,
+  includeIndexFileDependencies,
   isDebugEnabled,
   isInDetails,
   readRuntimeConfig,
@@ -108,4 +109,22 @@ test('isInDetails は環境変数 TSG_IN_DETAILS が設定されていない場�
   process.env = {};
   readRuntimeConfig('./src/utils/.test-danger-tsgrc.json');
   expect(isInDetails()).toBeTruthy();
+});
+
+test('includeIndexFileDependencies は環境変数もRuntimeConfigも設定されていない場合は false を 返す', () => {
+  process.env = {};
+  clearRuntimeConfig();
+  expect(includeIndexFileDependencies()).toBeFalsy();
+});
+
+test('includeIndexFileDependencies は .danger-tsgrc.json の debug より環境変数 TSG_INCLUDE_INDEX_FILE_DEPENDENCIES を優先して返す', () => {
+  process.env.TSG_INCLUDE_INDEX_FILE_DEPENDENCIES = 'false';
+  readRuntimeConfig('./src/utils/.test-danger-tsgrc.json');
+  expect(includeIndexFileDependencies()).toBeFalsy();
+});
+
+test('includeIndexFileDependencies は環境変数 TSG_INCLUDE_INDEX_FILE_DEPENDENCIES が設定されていない場合、.danger-tsgrc.json の debug を返す', () => {
+  process.env = {};
+  readRuntimeConfig('./src/utils/.test-danger-tsgrc.json');
+  expect(includeIndexFileDependencies()).toBeTruthy();
 });

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -3,7 +3,7 @@ import {
   getMaxSize,
   getOrientation,
   getTsconfigRoot,
-  includeIndexFileDependencies,
+  isIncludeIndexFileDependencies,
   isDebugEnabled,
   isInDetails,
   readRuntimeConfig,
@@ -114,17 +114,17 @@ test('isInDetails は環境変数 TSG_IN_DETAILS が設定されていない場�
 test('includeIndexFileDependencies は環境変数もRuntimeConfigも設定されていない場合は false を 返す', () => {
   process.env = {};
   clearRuntimeConfig();
-  expect(includeIndexFileDependencies()).toBeFalsy();
+  expect(isIncludeIndexFileDependencies()).toBeFalsy();
 });
 
 test('includeIndexFileDependencies は .danger-tsgrc.json の debug より環境変数 TSG_INCLUDE_INDEX_FILE_DEPENDENCIES を優先して返す', () => {
   process.env.TSG_INCLUDE_INDEX_FILE_DEPENDENCIES = 'false';
   readRuntimeConfig('./src/utils/.test-danger-tsgrc.json');
-  expect(includeIndexFileDependencies()).toBeFalsy();
+  expect(isIncludeIndexFileDependencies()).toBeFalsy();
 });
 
 test('includeIndexFileDependencies は環境変数 TSG_INCLUDE_INDEX_FILE_DEPENDENCIES が設定されていない場合、.danger-tsgrc.json の debug を返す', () => {
   process.env = {};
   readRuntimeConfig('./src/utils/.test-danger-tsgrc.json');
-  expect(includeIndexFileDependencies()).toBeTruthy();
+  expect(isIncludeIndexFileDependencies()).toBeTruthy();
 });

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -16,6 +16,8 @@ const dangerPluginTsgConfigScheme = z.object({
   inDetails: z.boolean().optional(),
   /** ファイルの除外対象 */
   exclude: z.array(z.string()).optional(),
+  /** 変更対象のファイルが同階層の index.ts などから参照されている場合、その index.ts への依存ファイルも表示するかどうか */
+  includeIndexFileDependencies: z.boolean().optional(),
 });
 
 export type DangerPluginTsgConfigScheme = z.infer<
@@ -99,4 +101,13 @@ export function isInDetails(): boolean {
 
 export function exclude(): string[] {
   return rc?.exclude ?? [];
+}
+
+/** 変更対象のファイルが同階層の index.ts などから参照されている場合、その index.ts への依存ファイルも表示するかどうか */
+export function includeIndexFileDependencies(): boolean {
+  return process.env.TSG_INCLUDE_INDEX_FILE_DEPENDENCIES === 'true'
+    ? true
+    : process.env.TSG_INCLUDE_INDEX_FILE_DEPENDENCIES === 'false'
+    ? false
+    : rc?.includeIndexFileDependencies ?? false;
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -104,7 +104,7 @@ export function exclude(): string[] {
 }
 
 /** 変更対象のファイルが同階層の index.ts などから参照されている場合、その index.ts への依存ファイルも表示するかどうか */
-export function includeIndexFileDependencies(): boolean {
+export function isIncludeIndexFileDependencies(): boolean {
   return process.env.TSG_INCLUDE_INDEX_FILE_DEPENDENCIES === 'true'
     ? true
     : process.env.TSG_INCLUDE_INDEX_FILE_DEPENDENCIES === 'false'

--- a/src/utils/reducer.ts
+++ b/src/utils/reducer.ts
@@ -1,0 +1,6 @@
+export function uniqueString(prev: string[], current: string) {
+  if (!prev.includes(current)) {
+    prev.push(current);
+  }
+  return prev;
+}


### PR DESCRIPTION
掲題の挙動を環境変数や rc で on/off 可能とした他、 deleted されたファイルが include 対象となっていない問題を解決した。